### PR TITLE
Fix ld.so.preload mess so we don't get Illegal instruction

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -7,7 +7,6 @@ set -x
 
 source /util.sh
 
-fixLd
 unpackHome
 unpackBoot
 apt-get update
@@ -122,7 +121,4 @@ unpackRoot
 sudo update-rc.d octoprint defaults 99
 
 #cleanup
-fixLd
 sudo apt-get clean
-
-sed -i 's@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' /etc/ld.so.preload

--- a/src/octopi
+++ b/src/octopi
@@ -39,6 +39,8 @@ pushd $OCTOPI_WORKSPACE
   pushd $MOUNT_PATH
 
     #make QEMU boot (remember to return)
+    source util.sh
+    fixLd
     #sed -i 's@include /etc/ld.so.conf.d/\*.conf@\#include /etc/ld.so.conf.d/\*.conf@' etc/ld.so.conf
 
     # execute the base chroot script
@@ -48,6 +50,8 @@ pushd $OCTOPI_WORKSPACE
     if [ -n $VARIANT_BASE ]; then
       execute_chroot_script $VARIANT_BASE $VARIANT_BASE/chroot_script
     fi
+    
+    restoreLd
   popd
   
   # unmount first boot, then root partition

--- a/src/util.sh
+++ b/src/util.sh
@@ -6,7 +6,11 @@ function die () {
 }
 
 function fixLd(){
-  sed -i 's@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' /etc/ld.so.preload
+  sed -i 's@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' etc/ld.so.preload
+}
+
+function restoreLd(){
+  sed -i 's@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' etc/ld.so.preload
 }
 
 function gitclone(){

--- a/src/variants/example/chroot_script
+++ b/src/variants/example/chroot_script
@@ -12,5 +12,4 @@ sudo sed -i 's@octopi@example@' /etc/hosts
 unpackRoot
 
 #cleanup
-fixLd
 sudo apt-get clean


### PR DESCRIPTION
Hey,
This fixes the illegal instruction error, but now evrey command that exists with return code 0 causes the trap to return an error.
